### PR TITLE
[BUGFIX] allow output minifiers by switching to multi-line JS comments

### DIFF
--- a/Resources/Private/Partials/Question/Chart.html
+++ b/Resources/Private/Partials/Question/Chart.html
@@ -2,13 +2,13 @@
 <div id="pollChart{question.uid}" class="apexchart apex-{settings.chart.type}"></div>
 <script>
 {
-  // Infos here: https://apexcharts.com/
+  /* Infos here: https://apexcharts.com/ */
   <f:if condition="{settings.chart.type} == 'pie' || {settings.chart.type} == 'donut'"><f:then>
 	let chartoptions = {
-		//title: {
-		//	text: '{question.title}',
-		//	align: 'left'
-		//},
+		/*title: {
+			text: '{question.title}',
+			align: 'left'
+		},*/
            chart: {
                width:	chartwidth,
                type:	charttype,
@@ -67,7 +67,7 @@
          }]
 	}
   </f:else></f:if>
-	
+
 	var chart{question.uid} = new ApexCharts(
 	    document.querySelector("#pollChart{question.uid}"),
 	    chartoptions

--- a/Resources/Private/Partials/Quiz/CheckFields.html
+++ b/Resources/Private/Partials/Quiz/CheckFields.html
@@ -1,6 +1,6 @@
 if (quizfinal == 0) {
 	$( "#quiz-form"+ceuid+" .quiz-radiobox" ).click(function() {
-		// add selected class to the selected answer and remove the class from other radio-buttons
+		/* add selected class to the selected answer and remove the class from other radio-buttons */
 		var closestRadio = $(this).closest( ".quiz-radio" );
 		var closestRadioParent = closestRadio.parent();
 		$(closestRadioParent).find('.quiz-radio').each(function() {
@@ -10,7 +10,7 @@ if (quizfinal == 0) {
 		$(this).closest( ".card" ).removeAttr("style");
 	});
 	$( "#quiz-form"+ceuid+" .quiz-checkboxes" ).click(function() {
-		// add/remove selected class to the selected checkbox answer
+		/* add/remove selected class to the selected checkbox answer */
 		var closestCheckbox = $(this).closest( ".quiz-checkbox" );
 		var closestCheckboxParent = closestCheckbox.parent();
 		$(closestCheckboxParent).find('.quiz-checkboxes').each(function() {
@@ -23,7 +23,7 @@ if (quizfinal == 0) {
 		});
 	});
 	$( "#quiz-form"+ceuid+" .quiz-select" ).change(function() {
-		// add selected class to the select if the selected val is not 0
+		/* add selected class to the select if the selected val is not 0 */
 		if ($(this).val() == '0') {
 			$(this).removeClass( 'quiz-answer-selected' );
 		} else {
@@ -32,7 +32,7 @@ if (quizfinal == 0) {
 		}
 	});
 	$( "#quiz-form"+ceuid+" .quiz-inputbox" ).change(function() {
-		// add selected class to the input if there is a value
+		/* add selected class to the input if there is a value */
 		if ($(this).val() == '') {
 			$(this).closest( ".quiz-input" ).removeClass( 'quiz-answer-selected' );
 		} else {
@@ -41,7 +41,7 @@ if (quizfinal == 0) {
 		}
 	});
 	$( "#quiz-form"+ceuid+" .quiz-textbox" ).change(function() {
-		// add selected class to the quiz-textarea if there is a value
+		/* add selected class to the quiz-textarea if there is a value */
 		if ($(this).val() == '') {
 			$(this).closest( ".quiz-textarea" ).removeClass( 'quiz-answer-selected' );
 		} else {

--- a/Resources/Private/Partials/Quiz/CheckForm.html
+++ b/Resources/Private/Partials/Quiz/CheckForm.html
@@ -4,35 +4,35 @@ function checkQuizForm() {
 	$('#quiz-form'+tempceuid+' .quiz-question-buttons').each(function() {
 		var noneSelected = true;
 		var selectedCounter = 0;
-		// radio-buttons
+		/* radio-buttons */
 		$(this).find('.quiz-radio').each(function() {
 			selectedCounter++;
 			if ($(this).hasClass('quiz-answer-selected') || $(this).hasClass('quiz-answer-optional')) {
 				noneSelected = false;
 			}
 		});
-		// Checkboxen
+		/* Checkboxen */
 		$(this).find('.quiz-checkbox').each(function() {
 			selectedCounter++;
 			if ($(this).hasClass('quiz-answer-selected') || $(this).hasClass('quiz-answer-optional')) {
 				noneSelected = false;
 			}
 		});
-		// Select-boxen
+		/* Select-boxen */
 		$(this).find('.quiz-select').each(function() {
 			selectedCounter++;
 			if ($(this).hasClass('quiz-answer-selected') || $(this).hasClass('quiz-answer-optional')) {
 				noneSelected = false;
 			}
 		});
-		// input-fields
+		/* input-fields */
 		$(this).find('.quiz-input').each(function() {
 			selectedCounter++;
 			if ($(this).hasClass('quiz-answer-selected') || $(this).hasClass('quiz-answer-optional')) {
 				noneSelected = false;
 			}
 		});
-		// textarea
+		/* textarea */
 		$(this).find('.quiz-textarea').each(function() {
 			selectedCounter++;
 			if ($(this).hasClass('quiz-answer-selected') || $(this).hasClass('quiz-answer-optional')) {

--- a/Resources/Private/Templates/Quiz/Show.html
+++ b/Resources/Private/Templates/Quiz/Show.html
@@ -1,6 +1,6 @@
 <html xmlns:f="https://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 	<f:layout name="Default" />
- 
+
 	<f:section name="content">
 		<f:flashMessages />
 		<f:form.validationResults>
@@ -29,7 +29,7 @@
 				var chartwidth = parseInt({settings.chart.width});
 			</script>
 		</f:if>
-		
+
 		{settings.template.wrapQuizTitle1 -> f:format.raw()}{quiz.name}{settings.template.wrapQuizTitle2 -> f:format.raw()}
 		<f:if condition="{quiz.media.0}">
 			<f:media file="{quiz.media.0}" alt="{quiz.media.0.originalResource.name}" title="{quiz.media.0.originalResource.title}" class="img-fluid" />
@@ -79,7 +79,7 @@
 				<f:form.hidden name="currentPage" value="1" id="quiz-form-page" />
 				<f:form.hidden name="showAnswers" value="0" id="quiz-form-answers" />
 				<f:form.hidden name="useJoker" value="0" id="quiz-form-joker" />
-	            
+
 	            <script>
 					ajaxVersion = true;
 					var quizanswers = 0;
@@ -94,9 +94,9 @@
 		        <script type="text/javascript">
 		            if (ajaxTypeSetting == 'GET') {	ajaxType = 'GET'; }
 				</script>
-				
+
 				<div id="quiz-ajaxCallResult"></div>
-				
+
 				<f:if condition="{settings.user.askForData} == 1">
 					<f:render partial="Participant/Form" arguments="{_all}" />
 				</f:if>
@@ -116,10 +116,10 @@
 						<f:form.submit value="{f:translate(key: 'text.goon')}" class="btn btn-primary btn-lg" name="quizGoOn" id="quiz-GoOn" />
 					</div>
 				</div>
-				
+
 				<script>
 					<f:render partial="Quiz/CheckForm" arguments="{uidOfCE: uidOfCE}" />
-					
+
 					document.addEventListener('DOMContentLoaded', function(){
 			            var form = $('#quiz-form'+ceuid);
 			            var resultContainer = $('#quiz-ajaxCallResult');
@@ -131,7 +131,7 @@
 			                        type: ajaxType,
 			                        data: data.serialize(),
 			                        success: function (result) {
-			                        	// display the AJAX-result and set the JS-variable quizfinal
+			                        	/* display the AJAX-result and set the JS-variable quizfinal */
 			                            resultContainer.html(result).show();
 			                            <f:render partial="Quiz/CheckFields" arguments="{uidOfCE: uidOfCE}" />
 				                       	var thisQuizPage = $('#quiz-form-page').val();
@@ -174,7 +174,7 @@
 			            });
 			            service.ajaxCall(form);
 					}, false);
-					
+
 					function getQuizJoker() {
 						$('#quiz-form'+ceuid+' #quiz-form-page').val(thisPage);
 						$('#quiz-form'+ceuid+' #quiz-form-answers').val('0');
@@ -198,7 +198,7 @@
 				<f:form.hidden name="showAnswers" value="{showAnswersNext}" />
 				<f:form.hidden name="session" value="{session}" />
 				<f:form.hidden name="startTime" value="{startTime}" />
-				
+
 				<f:if condition="{final} == 0">
 					<f:then>
 						<f:if condition="({settings.showPageNo} == 1) && ({pages} != 1)">
@@ -211,20 +211,20 @@
 								</div>
 							</p>
 						</f:if>
-						
+
 						<f:if condition="{showAnswers}">
 							<f:then>
-							
+
 								<!--  show answers after submit -->
 								<f:for each="{participantPaginator.paginatedItems}" as="selection" iteration="pageiterator">
 									<f:render partial="Question/PropertiesSent" arguments="{_all}" />
 								</f:for>
 
 								<f:if condition="{settings.showPoints} && ({participant.maximum1} > 0)">
-									<f:comment> {participant -> f:debug(title: 'Members of participant')} </f:comment> 
+									<f:comment> {participant -> f:debug(title: 'Members of participant')} </f:comment>
 									<p>{f:translate(key: "text.pointsYet")} {participant.points}/{participant.maximum1}.</p>
 								</f:if>
-				
+
 								<div>
 									<div class="pull-right quiz-subm">
 										<f:form.button type="submit" name="quizGoOn" class="btn btn-primary btn-lg">
@@ -239,10 +239,10 @@
 										</f:form.button>
 									</div>
 								</div>
-								
+
 							</f:then>
 							<f:else>
-						
+
 								<!-- show questions -->
 								<f:for each="{quizPaginator.paginatedItems}" as="question" iteration="pageiterator">
 									<f:render partial="Question/Properties" arguments="{_all}" />
@@ -280,14 +280,14 @@
 										</f:form.button>
 									</div>
 								</div>
-						
+
 								<script>
 									<f:render partial="Quiz/CheckForm" arguments="{uidOfCE: uidOfCE}" />
 									document.addEventListener('DOMContentLoaded', function(){
                                         <f:render partial="Quiz/CheckFields" arguments="{uidOfCE: uidOfCE}" />
 
                                         $( "#quiz-GoOn" ).click(function() {
-                                            // check if there are selected answers to all questions. if not, show an warning
+                                            /* check if there are selected answers to all questions. if not, show an warning */
                                             var allSelected = checkQuizForm();
                                             if (noFormCheck || allSelected) {
                                                 $('#quiz-form'+ceuid).submit();
@@ -322,7 +322,7 @@
 					<f:else>
 
 						<f:render partial="Quiz/FinalPage" arguments="{_all}" />
-						
+
 					</f:else>
 				</f:if>
 			</f:form>

--- a/Resources/Private/Templates/Quiz/ShowByTag.html
+++ b/Resources/Private/Templates/Quiz/ShowByTag.html
@@ -212,7 +212,7 @@
                                 }
 
                                 $("#quiz-GoOn").click(function () {
-                                    // check if there are selected answers to all questions. if not, show an warning
+                                    /* check if there are selected answers to all questions. if not, show an warning */
                                     var allSelected = checkQuizForm();
                                     if (noFormCheck || allSelected) {
                                         $('#quiz-form' + ceuid).submit();


### PR DESCRIPTION
e.g. EXT:min breaks the current output as the line break after single-line
comments in the JavaScript includes is removed. Thus replacing that with
multi-line comment syntax resolves the issue.